### PR TITLE
protocols/autonat/examples: Add client example

### DIFF
--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -19,3 +19,9 @@ libp2p-core = { version = "0.30.1", path = "../../core" }
 libp2p-swarm = { version = "0.32.0", path = "../../swarm" }
 libp2p-request-response = { version = "0.14.0", path = "../request-response" }
 prost = "0.8"
+
+[dev-dependencies]
+async-std = { version = "1.7.0", features = ["attributes"] }
+env_logger = "0.9.0"
+libp2p = { path = "../.." }
+structopt = "0.3.21"

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -26,5 +26,5 @@ prost = "0.8"
 [dev-dependencies]
 async-std = { version = "1.10", features = ["attributes"] }
 env_logger = "0.9.0"
-libp2p = { path = "../../", default-features = false, features = ["dns-async-std", "mplex", "noise", "tcp-async-io", "websocket", "yamux"]}
+libp2p = { path = "../../", default-features = false, features = ["autonat", "dns-async-std", "identify", "mplex", "noise", "tcp-async-io", "websocket", "yamux"]}
 structopt = "0.3.21"

--- a/protocols/autonat/examples/client.rs
+++ b/protocols/autonat/examples/client.rs
@@ -1,0 +1,119 @@
+// Copyright 2021 Protocol Labs.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use futures::prelude::*;
+use libp2p::autonat;
+use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
+use libp2p::swarm::{AddressScore, Swarm, SwarmEvent};
+use libp2p::{identity, Multiaddr, NetworkBehaviour, PeerId};
+use std::error::Error;
+use std::time::Duration;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "libp2p relay")]
+struct Opt {
+    #[structopt(long)]
+    server_address: Multiaddr,
+
+    #[structopt(long)]
+    server_peer_id: PeerId,
+}
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    let opt = Opt::from_args();
+
+    let local_key = identity::Keypair::generate_ed25519();
+    let local_peer_id = PeerId::from(local_key.public());
+    println!("Local peer id: {:?}", local_peer_id);
+
+    let transport = libp2p::development_transport(local_key.clone()).await?;
+
+    let behaviour = Behaviour::new(local_key.public());
+
+    let mut swarm = Swarm::new(transport, behaviour, local_peer_id);
+    swarm.listen_on("/ip4/0.0.0.0/tcp/0".parse()?)?;
+
+    swarm
+        .behaviour_mut()
+        .auto_nat
+        .add_server(opt.server_peer_id, Some(opt.server_address))
+        .then(|| Some(()))
+        .expect("Auto retry to be enabled.");
+
+    swarm.add_external_address(Multiaddr::empty(), AddressScore::Infinite);
+
+    loop {
+        match swarm.select_next_some().await {
+            SwarmEvent::NewListenAddr { address, .. } => println!("Listening on {:?}", address),
+            SwarmEvent::Behaviour(event) => println!("{:?}", event),
+            e => println!("{:?}", e),
+        }
+    }
+}
+
+#[derive(NetworkBehaviour)]
+#[behaviour(out_event = "Event")]
+struct Behaviour {
+    identify: Identify,
+    auto_nat: autonat::behaviour::Behaviour,
+}
+
+impl Behaviour {
+    fn new(local_public_key: identity::PublicKey) -> Self {
+        Self {
+            identify: Identify::new(IdentifyConfig::new(
+                "/ipfs/0.1.0".into(),
+                local_public_key.clone(),
+            )),
+            auto_nat: autonat::behaviour::Behaviour::new(
+                local_public_key.to_peer_id(),
+                autonat::behaviour::Config {
+                    auto_retry: Some(autonat::behaviour::AutoRetry {
+                        interval: Duration::from_secs(10),
+                        config: autonat::behaviour::ProbeConfig::default(),
+                    }),
+                    ..autonat::behaviour::Config::default()
+                },
+            ),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Event {
+    AutoNat(autonat::behaviour::NatStatus),
+    Identify(IdentifyEvent),
+}
+
+impl From<IdentifyEvent> for Event {
+    fn from(v: IdentifyEvent) -> Self {
+        Self::Identify(v)
+    }
+}
+
+impl From<autonat::behaviour::NatStatus> for Event {
+    fn from(v: autonat::behaviour::NatStatus) -> Self {
+        Self::AutoNat(v)
+    }
+}


### PR DESCRIPTION
Hope this can be of some use.

Example to connect to an IPFS bootstrap node:

```
cargo run --example client -- --server-address /ip4/104.131.131.82/tcp/4001 --server-peer-id QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
```